### PR TITLE
Add CSV import module

### DIFF
--- a/bin/csv_import.py
+++ b/bin/csv_import.py
@@ -1,0 +1,35 @@
+import csv
+import json
+import os
+import sqlite3
+import sys
+
+DB_FILE = os.environ.get('CSV_IMPORT_DB', os.path.join(os.path.dirname(__file__), '..', 'var', 'data_import.db'))
+TABLE_NAME = 'csv_records'
+
+
+def setup_db(conn):
+    conn.execute(f"CREATE TABLE IF NOT EXISTS {TABLE_NAME} (id INTEGER PRIMARY KEY AUTOINCREMENT, data TEXT)")
+    conn.commit()
+
+
+def import_csv(path):
+    conn = sqlite3.connect(DB_FILE)
+    setup_db(conn)
+    with open(path, newline='') as csvfile:
+        reader = csv.DictReader(csvfile)
+        rows = [json.dumps(row) for row in reader]
+        conn.executemany(f"INSERT INTO {TABLE_NAME} (data) VALUES (?)", [(r,) for r in rows])
+        conn.commit()
+    conn.close()
+
+
+def main():
+    if len(sys.argv) < 2:
+        print('Usage: csv_import.py <csv_file>')
+        sys.exit(1)
+    import_csv(sys.argv[1])
+
+
+if __name__ == '__main__':
+    main()

--- a/src/Command/CsvImportCommand.php
+++ b/src/Command/CsvImportCommand.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Command;
+
+use App\Service\CsvImportService;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(name: 'app:csv-import')]
+class CsvImportCommand extends Command
+{
+    public function __construct(private CsvImportService $importService)
+    {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addArgument('file', InputArgument::REQUIRED, 'CSV file to import');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $file = $input->getArgument('file');
+        $this->importService->import($file);
+        $output->writeln('Import completed');
+        return Command::SUCCESS;
+    }
+}

--- a/src/Controller/CsvImportController.php
+++ b/src/Controller/CsvImportController.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Controller;
+
+use App\Service\CsvImportService;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Attribute\Route;
+
+class CsvImportController extends AbstractController
+{
+    #[Route('/import-csv', name: 'csv_import', methods: ['GET', 'POST'])]
+    public function index(Request $request, CsvImportService $service): Response
+    {
+        if ($request->isMethod('POST')) {
+            /** @var UploadedFile $file */
+            $file = $request->files->get('csv_file');
+            if ($file) {
+                $path = $this->getParameter('kernel.project_dir').'/var/uploads/'.$file->getClientOriginalName();
+                $file->move(dirname($path), basename($path));
+                $service->import($path);
+                $this->addFlash('success', 'Import réalisé avec succès');
+            }
+            return $this->redirectToRoute('csv_import');
+        }
+
+        return $this->render('csv_import/index.html.twig');
+    }
+}

--- a/src/Service/CsvImportService.php
+++ b/src/Service/CsvImportService.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Service;
+
+use Symfony\Component\Process\Process;
+
+class CsvImportService
+{
+    public function import(string $path): void
+    {
+        $process = new Process(['python3', __DIR__.'/../../bin/csv_import.py', $path]);
+        $process->setTimeout(null);
+        $process->run();
+
+        if (!$process->isSuccessful()) {
+            throw new \RuntimeException('CSV import failed: '.$process->getErrorOutput());
+        }
+    }
+}

--- a/templates/csv_import/index.html.twig
+++ b/templates/csv_import/index.html.twig
@@ -1,0 +1,38 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Import CSV{% endblock %}
+
+{% block body %}
+<div class="container">
+    <h1>Import CSV</h1>
+    {% for message in app.flashes('success') %}
+        <div class="alert alert-success">{{ message }}</div>
+    {% endfor %}
+    <form method="post" enctype="multipart/form-data" id="dropzone-form">
+        <div id="dropzone" style="border: 2px dashed #ccc; padding: 30px; text-align:center;">
+            Déposez votre fichier ici ou cliquez pour sélectionner.
+            <input type="file" name="csv_file" id="file-input" style="display:none" accept="text/csv" required>
+        </div>
+        <button class="btn btn-primary mt-3">Importer</button>
+    </form>
+</div>
+<script>
+    const dropzone = document.getElementById('dropzone');
+    const fileInput = document.getElementById('file-input');
+
+    dropzone.addEventListener('click', () => fileInput.click());
+
+    dropzone.addEventListener('dragover', (e) => {
+        e.preventDefault();
+        dropzone.classList.add('bg-light');
+    });
+
+    dropzone.addEventListener('dragleave', () => dropzone.classList.remove('bg-light'));
+
+    dropzone.addEventListener('drop', (e) => {
+        e.preventDefault();
+        fileInput.files = e.dataTransfer.files;
+        dropzone.classList.remove('bg-light');
+    });
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add csv_import.py to parse and store rows in SQLite
- create CsvImportService using Process component
- create CsvImportCommand for command line usage
- add CsvImportController with upload form
- add dropzone-based Twig template for CSV import

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6848a8cb22f48320a6f35e2158688873